### PR TITLE
Core: Added option for a user provided custom loading strategy

### DIFF
--- a/src/jsgrid.core.js
+++ b/src/jsgrid.core.js
@@ -118,6 +118,7 @@
         pageClass: "jsgrid-pager-page",
         currentPageClass: "jsgrid-pager-current-page",
 
+        customLoading: false,
         pageLoading: false,
 
         autoload: false,
@@ -157,6 +158,9 @@
         },
 
         loadStrategy: function() {
+            if(this.customLoading) {
+               return new jsGrid.loadStrategies.CustomLoadingStrategy(this);
+            }
             return this.pageLoading
                 ? new jsGrid.loadStrategies.PageLoadingStrategy(this)
                 : new jsGrid.loadStrategies.DirectLoadingStrategy(this);


### PR DESCRIPTION
Hi,
Thank you for this nice and clean plugin.
I needed to adapt the response from the server before it could be consumed by the widget, and avoiding to craft a different response for this particular widget. Therefore I have added a custom loading strategy where I can adapt things to my particular setup. I think it is a rather common scenario, hence my pull-request that makes this possible. It's not particularly elegant, but I wanted to change as little as possible.
Also, I did not add anything in _handleOptionChange.
So probably you would want to consider this rather as a feature request than a pull request.