### PR TITLE
Fixed Firefox td width issues.

### DIFF
--- a/src/jsgrid.core.js
+++ b/src/jsgrid.core.js
@@ -613,7 +613,7 @@
             }
 
             $result.addClass(field.css);
-            $result.css("width": field.width);
+            $result.css({"width": field.width});
             
 
             field.align && $result.addClass("jsgrid-align-" + field.align);

--- a/src/jsgrid.core.js
+++ b/src/jsgrid.core.js
@@ -612,8 +612,9 @@
                 $result = $("<td>").append(field.itemTemplate ? field.itemTemplate(fieldValue, item) : fieldValue);
             }
 
-            $result.addClass(field.css)
-                .width(field.width);
+            $result.addClass(field.css);
+            $result.css("width": field.width);
+            
 
             field.align && $result.addClass("jsgrid-align-" + field.align);
 


### PR DESCRIPTION
Setting the field width gives incorrect values in Firefox. The header cells have the correct width, but the data columns do not. For some reason Firefox, and only Firefox, adds 30 to whatever value is given. Everything works fine in Chrome.

HTML OUTPUT
```html
<th class="jsgrid-header-sortable" style=width: 5%,">System</th>
...
<tr class="jsgrid-row">
<td style="width: 35%,">Some Value</td>
...
```
It doesn't matter if the field width is set to a percentage or a px value, it always adds 30 (ie 5% -> 35%, 100px -> 130px, etc).  This was causing the headers to not line up properly with the data columns. I was able to fix the issue by modifying js.grid.core.js and changing the way that _createCell sets the width of the element.

Before
```javascript
_createCell: function(item, field) {
...
$result..addClass(field.css).width(field.width);
``` 
After
```javascript
_createCell: function(item, field) {
...
$result..addClass(field.css);
$result.css("width":field.width);
``` 