### PR TITLE
Added support for dot notation properties binding.

### DIFF
--- a/src/jsgrid.core.js
+++ b/src/jsgrid.core.js
@@ -606,9 +606,20 @@
             return this;
         },
 
+        _getFieldValue: function(item, name, field) {
+            var props = name.split('.');
+            var fieldValue = item[props.shift()];
+
+            while (props.length > 0) {
+                fieldValue = fieldValue[props.shift()];
+            }
+
+            return fieldValue;
+        },
+
         _createCell: function(item, field) {
             var $result;
-            var fieldValue = item[field.name];
+            var fieldValue = this._getFieldValue(item, field.name, field);
 
             if($.isFunction(field.cellRenderer)) {
                 $result = $(field.cellRenderer(fieldValue, item));
@@ -1096,10 +1107,12 @@
 
             var $result = $("<tr>").addClass(this.editRowClass);
 
+            var self = this;
             this._eachField(function(field) {
+                var fieldValue = self._getFieldValue(item, field.name, field);
                 $("<td>").addClass(field.editcss || field.css)
                     .appendTo($result)
-                    .append(field.editTemplate ? field.editTemplate(item[field.name], item) : "")
+                    .append(field.editTemplate ? field.editTemplate(fieldValue, item) : "")
                     .width(field.width || "auto");
             });
 


### PR DESCRIPTION
Added support to bind child properties of an object with the fields using dot notation syntax:

    { title: "City", name: "Address.City", type: "text", width: 200 },


**Example:**
```javascript

$("#jsGrid").jsGrid({
    width: "100%",
    height: "400px",

    filtering: true,
    editing: true,
    sorting: true,
    paging: true,

    data: db.clients,

    fields: [
        { name: "Name", type: "text", width: 150 },
        { name: "Age", type: "number", width: 50 },
        { title: "City", name: "Address.City", type: "text", width: 200 },
        { title: "State", name: "Address.State", type: "text", width: 200 },
        { name: "Country", type: "select", items: db.countries, valueField: "Id", textField: "Name" },
        { name: "Married", type: "checkbox", title: "Is Married", sorting: false },
        { type: "control" }
    ]
});

```