### PR TITLE
Added support for default-value on item insert

### DIFF
--- a/src/fields/jsgrid.field.select.js
+++ b/src/fields/jsgrid.field.select.js
@@ -21,6 +21,7 @@
 
         align: "center",
         valueType: "number",
+        defaultValue: undefined,
 
         itemTemplate: function(value) {
             var items = this.items,
@@ -62,7 +63,12 @@
             if(!this.inserting)
                 return "";
 
-            return this.insertControl = this._createSelect();
+            this.insertControl = this._createSelect();
+            if(this.defaultValue) {
+                this.insertControl.val(this.defaultValue);
+            }
+
+            return this.insertControl;
         },
 
         editTemplate: function(value) {

--- a/src/fields/jsgrid.field.text.js
+++ b/src/fields/jsgrid.field.text.js
@@ -9,7 +9,8 @@
     TextField.prototype = new Field({
 
         autosearch: true,
-		readOnly: false,
+        readOnly: false,
+        defaultValue: undefined,
 
         filterTemplate: function() {
             if(!this.filtering)
@@ -34,7 +35,7 @@
             if(!this.inserting)
                 return "";
 
-            return this.insertControl = this._createTextBox();
+            return this.insertControl = this._createTextBox().val(this.defaultValue);
         },
 
         editTemplate: function(value) {

--- a/tests/jsgrid.field.tests.js
+++ b/tests/jsgrid.field.tests.js
@@ -105,6 +105,13 @@ $(function() {
         equal($element.jsGrid("option", "fields")[0].defaultOption, "test", "default field option set");
     });
 
+    test("insert default value", function() {
+      var field = new jsGrid.TextField({ defaultValue: "foo" });
+
+      field.insertTemplate();
+      strictEqual(field.insertValue(), "foo");
+    });
+
 
     module("jsGrid.field.number");
 
@@ -118,6 +125,13 @@ $(function() {
         strictEqual(field.filterValue(), 0);
         strictEqual(field.insertValue(), 0);
         strictEqual(field.editValue(), 6);
+    });
+
+    test("insert default value", function() {
+      var field = new jsGrid.NumberField({ defaultValue: 42 });
+
+      field.insertTemplate();
+      strictEqual(field.insertValue(), 42);
     });
 
 
@@ -307,6 +321,22 @@ $(function() {
 
         field.textField = "text";
         strictEqual(field.itemTemplate(1), "test1");
+    });
+
+    test("insert default value", function() {
+      var field = new jsGrid.SelectField({
+          name: "testField",
+          items: [
+              { text: "test1", value: "foo" },
+              { text: "test2", value: "bar" },
+              { text: "test3", value: "baz" },
+          ],
+          valueField: "value",
+          defaultValue: "bar"
+      });
+
+      field.insertTemplate();
+      equal(field.insertValue(), "bar");
     });
 
 


### PR DESCRIPTION
I've added support for default field values when inserting new items, for text/number and select fields.

This is different from e.g. the select field's *selectedIndex* in that it only takes effect when inserting new items, whereas *selectedIndex* also applies to filtering (*defaultValue* has precedence over *selectedIndex*).

It would be nice implementing this as a general feature in core, instead of per-fieldtype, but given the documentation of *insertTemplate* I get the impression it's allowed to return arbitrarily complex element, not necessarily an input element you can directly set a value for.