### PR TITLE
Added better configuration of buttons in 'control' field.

### DIFF
--- a/src/fields/jsgrid.field.control.js
+++ b/src/fields/jsgrid.field.control.js
@@ -44,6 +44,8 @@
         deleteButton: true,
         clearFilterButton: true,
         modeSwitchButton: true,
+        searchButton: true,
+        insertButton: true,
 
         _initConfig: function() {
             this._hasFiltering = this._grid.filtering;
@@ -91,16 +93,16 @@
         },
 
         filterTemplate: function() {
-            var $result = this._createSearchButton();
+            var $result = this.searchButton ? this._createSearchButton() : $("");
             return this.clearFilterButton ? $result.add(this._createClearFilterButton()) : $result;
         },
 
         insertTemplate: function() {
-            return this._createInsertButton();
+            return this.insertButton ? this._createInsertButton() : $("");
         },
 
         editTemplate: function() {
-            return this._createUpdateButton().add(this._createCancelEditButton());
+            return this.editButton ? this._createUpdateButton().add(this._createCancelEditButton()) : $("");
         },
 
         _createFilterSwitchButton: function() {


### PR DESCRIPTION
Added toggles for **searchButton** and **editButton** for the *control* field type, and change the **editTemplate** so it only has the update/cancel buttons if **editButton** is true.

This might seem like an odd idea at first, but is useful if you want to have control buttons outside the grid, or want several control fields with different functionality. I have a feature request for moving the delete button to a separate column, because users hit it by accident after cancelling an edit.

A demonstration is available [here](http://plnkr.co/edit/zhH4kO?p=preview) - the oldest version uses version 1.4.1 of js-grid, which has slightly weird UX, while the most recent Plunk version uses js-grid built from my feature branch.