### PR TITLE
Allow select dropdown text to render html character codes

### DIFF
--- a/src/fields/jsgrid.field.select.js
+++ b/src/fields/jsgrid.field.select.js
@@ -104,7 +104,7 @@
 
                 var $option = $("<option>")
                     .attr("value", value)
-                    .text(text)
+                    .html(text)
                     .appendTo($result);
 
                 $option.prop("selected", (selectedIndex === index));


### PR DESCRIPTION
Change .text to .html in option creation to allow for html character codes such as `&nbsp;` to display correctly in the dropdowns.