### PR TITLE
Update jsgrid.field.select.js

### DIFF
--- a/src/fields/jsgrid.field.select.js
+++ b/src/fields/jsgrid.field.select.js
@@ -33,7 +33,7 @@
 
             if(valueField) {
                 resultItem = $.grep(items, function(item, index) {
-                    return item[valueField] === value;
+                    return item[valueField] == value;
                 })[0] || {};
             }
             else {


### PR DESCRIPTION
If using == and not of using ===
otherwise the check on valueField must be exact the same

if the valuetype is integer it seems not working if you are using ===