### PR TITLE
Allow for -1 SelectedIndex assignments in the <Select> Element

### DIFF
--- a/src/fields/jsgrid.field.select.js
+++ b/src/fields/jsgrid.field.select.js
@@ -107,10 +107,10 @@
                     .text(text)
                     .appendTo($result);
 
-                $option.prop("selected", (selectedIndex === index));
             });
 
             $result.prop("disabled", !!this.readOnly);
+			$result.prop('selectedIndex', selectedIndex);
 
             return $result;
         }

--- a/src/fields/jsgrid.field.select.js
+++ b/src/fields/jsgrid.field.select.js
@@ -110,8 +110,8 @@
             });
 
             $result.prop("disabled", !!this.readOnly);
-			$result.prop('selectedIndex', selectedIndex);
-
+            $result.prop("selectedIndex", selectedIndex);
+			
             return $result;
         }
     });


### PR DESCRIPTION
**Problem**
Currently, [the documentation uses an example for the select element that sets the selectedIndex to -1 ](http://js-grid.com/docs/#select)(Which means don't pre-select anything). 

However, with the current implementation this is impossible because the selectedIndex is assigned within the option creation loop. If the option's index matches selectedIndex, the code assigns the "selected" property. Since an option's index will never be negative, the negative index is never applied. 

**Solution**
I've moved the selectedIndex property assignment outside of the option creation loop. This allows for the index to be set properly regardless of its position. 