### PR TITLE
Add style when fields have 'readonly' props

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -92,6 +92,11 @@
     border: #f3f3f3 1px solid;
 }
 
+.jsgrid-cell.readonly > input {
+    border: 1px solid #dbdee0 !important;
+    color: #888;
+}
+
 .jsgrid-grid-body .jsgrid-row:first-child .jsgrid-cell,
 .jsgrid-grid-body .jsgrid-alt-row:first-child .jsgrid-cell {
     border-top: none;

--- a/src/jsgrid.core.js
+++ b/src/jsgrid.core.js
@@ -484,6 +484,7 @@
         _prepareCell: function(cell, field, cssprop, cellClass) {
             return $(cell).css("width", field.width)
                 .addClass(cellClass || this.cellClass)
+                .addClass(field.readOnly ? 'readonly' : '')
                 .addClass((cssprop && field[cssprop]) || field.css)
                 .addClass(field.align ? ("jsgrid-align-" + field.align) : "");
         },


### PR DESCRIPTION
There was no change when the cell had 'readOnly' attribute.
I added it and it seems useful.
So I opened a pull request.
Thank you.
