### PR TITLE
Added resizing ability to columns

### DIFF
--- a/css/jsgrid.css
+++ b/css/jsgrid.css
@@ -42,9 +42,11 @@
     padding: 0.5em 0.5em;
 }
 
-.jsgrid-сell,
-.jsgrid-header-cell {
+.jsgrid-сell {
     box-sizing: border-box;
+}
+.jsgrid-header-cell {
+    position: relative;
 }
 
 .jsgrid-align-left {
@@ -65,7 +67,7 @@
     text-align: right;
 }
 
-.jsgrid-header-cell {
+.jsgrid-header-title {
     padding: .5em .5em;
 }
 
@@ -100,6 +102,18 @@
 
 .jsgrid-header-sort {
     cursor: pointer;
+}
+
+.jsgrid-header-resize {
+    display: block;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    right: -3px;
+    width: 6px;
+    background: transparent;
+    z-index: 2;
+    cursor: ew-resize;
 }
 
 .jsgrid-pager {

--- a/css/theme.css
+++ b/css/theme.css
@@ -65,7 +65,7 @@
     background: #c4e2ff;
 }
 
-.jsgrid-header-sort:before {
+.jsgrid-header-sort > .jsgrid-header-title::before {
     content: " ";
     display: block;
     float: left;
@@ -74,12 +74,12 @@
     border-style: solid;
 }
 
-.jsgrid-header-sort-asc:before {
+.jsgrid-header-sort-asc > .jsgrid-header-title:before {
     border-width: 0 5px 5px 5px;
     border-color: transparent transparent #009a67 transparent;
 }
 
-.jsgrid-header-sort-desc:before {
+.jsgrid-header-sort-desc > .jsgrid-header-title:before {
     border-width: 5px 5px 0 5px;
     border-color: #009a67 transparent transparent transparent;
 }

--- a/demos/basic.html
+++ b/demos/basic.html
@@ -37,6 +37,7 @@
                 editing: true,
                 inserting: true,
                 sorting: true,
+                resizing: true,
                 paging: true,
                 autoload: true,
                 pageSize: 15,

--- a/src/jsgrid.field.js
+++ b/src/jsgrid.field.js
@@ -17,6 +17,7 @@
         inserting: true,
         editing: true,
         sorting: true,
+        resizing: true,
         sorter: "string", // name of SortStrategy or function to compare elements
         
         includeInDataExport: true,


### PR DESCRIPTION
Columns can now be resized by clicking and dragging the right-edge of a column. Had to add an additional inner element to the <th> element to avoid unwanted clicks causing the column to sort on resize.

Addresses issue #9 