### PR TITLE
dist/jsgrid.css: Corrected encoding

### DIFF
--- a/dist/jsgrid.css
+++ b/dist/jsgrid.css
@@ -48,7 +48,7 @@
     padding: 0.5em 0.5em;
 }
 
-.jsgrid-сell,
+.jsgrid-cell,
 .jsgrid-header-cell {
     box-sizing: border-box;
 }


### PR DESCRIPTION
Strangely that line was using some unusual character encoding.
Parsing an SCSS file based on this one, https://github.com/leafo/scssphp crashed over there.