### PR TITLE
Fixed URL in OData Service demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules
 dist
 _site
+*~

--- a/demos/odata-service.html
+++ b/demos/odata-service.html
@@ -44,7 +44,7 @@
                         var d = $.Deferred();
 
                         $.ajax({
-                            url: "http://services.odata.org/V3/(S(3mnweai3qldmghnzfshavfok))/OData/OData.svc/Products",
+                            url: "https://services.odata.org/V3/(S(3mnweai3qldmghnzfshavfok))/OData/OData.svc/Products",
                             dataType: "json"
                         }).done(function(response) {
                             d.resolve(response.value);


### PR DESCRIPTION
The old http URL redirects to https and then hangs.  This goes direct to the https version of the URL.