### PR TITLE
Allow objects to be passed into SelectField

### DIFF
--- a/src/fields/jsgrid.field.select.js
+++ b/src/fields/jsgrid.field.select.js
@@ -32,7 +32,7 @@
                 resultItem;
 
             if(valueField) {
-                if($.type(value) === "object"){
+                if(typeof(value) === "object"){
                     resultItem = value;
                 }
                 else{
@@ -79,7 +79,7 @@
 
             var $result = this.editControl = this._createSelect();
             var editValue = value;
-            if($.type(value) === "object"){
+            if(typeof(value) === "object"){
                 editValue = value[this.valueField];
             }
             (editValue !== undefined) && $result.val(editValue);

--- a/src/fields/jsgrid.field.select.js
+++ b/src/fields/jsgrid.field.select.js
@@ -32,9 +32,14 @@
                 resultItem;
 
             if(valueField) {
-                resultItem = $.grep(items, function(item, index) {
-                    return item[valueField] === value;
-                })[0] || {};
+                if($.type(value) === "object"){
+                    resultItem = value;
+                }
+                else{
+                    resultItem = $.grep(items, function(item, index) {
+                        return item[valueField] === value;
+                    })[0] || {};
+                }
             }
             else {
                 resultItem = items[value];

--- a/src/fields/jsgrid.field.select.js
+++ b/src/fields/jsgrid.field.select.js
@@ -78,7 +78,11 @@
                 return this.itemTemplate.apply(this, arguments);
 
             var $result = this.editControl = this._createSelect();
-            (value !== undefined) && $result.val(value);
+            var editValue = value;
+            if($.type(value) === "object"){
+                editValue = value[this.valueField];
+            }
+            (editValue !== undefined) && $result.val(editValue);
             return $result;
         },
 

--- a/tests/jsgrid.field.tests.js
+++ b/tests/jsgrid.field.tests.js
@@ -337,6 +337,26 @@ $(function() {
         strictEqual(field.itemTemplate(1), "test1");
     });
 
+    test("object as input", function() {
+        var field = new jsGrid.SelectField({
+            name: "testField",
+            items: [
+                { text: "test1", value: 1 },
+                { text: "test2", value: 2 },
+                { text: "test3", value: 3 }
+            ],
+            valueField: "value",
+            textField: "text"
+        });
+
+        
+        strictEqual(field.itemTemplate({ text: "test1", value: 1 }), "test1");
+        strictEqual(field.itemTemplate({ text: "test2", value: 2 }), "test2");
+        strictEqual(field.itemTemplate({ text: "test3", value: 3 }), "test3");
+
+
+    });
+
 
     module("jsGrid.field.control");
 

--- a/tests/jsgrid.field.tests.js
+++ b/tests/jsgrid.field.tests.js
@@ -355,9 +355,18 @@ $(function() {
         strictEqual(field.itemTemplate({ text: "test2", value: 2 }), "test2");
         strictEqual(field.itemTemplate({ text: "test3", value: 3 }), "test3");
 
-        strictEqual(field.editTemplate({ text: "test1", value: 1 }), "test1");
-        strictEqual(field.editTemplate({ text: "test2", value: 2 }), "test2");
-        strictEqual(field.editTemplate({ text: "test3", value: 3 }), "test3");
+
+
+        field.editTemplate({ text: "test1", value: 1 });
+        strictEqual(field.editValue(), 1);
+        
+        field.editTemplate({ text: "test2", value: 2 });
+        strictEqual(field.editValue(), 2);
+        
+        field.editTemplate({ text: "test3", value: 3 });
+        strictEqual(field.editValue(), 3);
+
+
 
 
     });

--- a/tests/jsgrid.field.tests.js
+++ b/tests/jsgrid.field.tests.js
@@ -350,9 +350,14 @@ $(function() {
         });
 
         
+
         strictEqual(field.itemTemplate({ text: "test1", value: 1 }), "test1");
         strictEqual(field.itemTemplate({ text: "test2", value: 2 }), "test2");
         strictEqual(field.itemTemplate({ text: "test3", value: 3 }), "test3");
+
+        strictEqual(field.editTemplate({ text: "test1", value: 1 }), "test1");
+        strictEqual(field.editTemplate({ text: "test2", value: 2 }), "test2");
+        strictEqual(field.editTemplate({ text: "test3", value: 3 }), "test3");
 
 
     });


### PR DESCRIPTION
With this little bit of code we can allow the select field to receive an object rather than just an integer, this is very useful for when a REST API sends nested data rather than just ID's that are references to the data.

e.g

with the field set up like so:

    {
         name: "job",
         type: "select",
         items: [*some_array_of_choices*],
         valueField: "id",
         textField: "title",
         title: "Job",
     },

Rather than
`
{
    "id": 1,
    "name": "John Doe",
    "job": 1
}
`
we can now pass something like this
`
{
    "id": 1,
    "name": "John Doe",
    "job": {
        "title": "Manager",
        "id": 1
    }
}
`