### PR TITLE
Adding natural sorting as a sorting strategy

### DIFF
--- a/src/jsgrid.sort-strategies.js
+++ b/src/jsgrid.sort-strategies.js
@@ -17,6 +17,19 @@
 
             return ("" + str1).localeCompare("" + str2);
         },
+        
+        stringNaturalSort: function(str1, str2) {
+            if(!isDefined(str1) && !isDefined(str2))
+                return 0;
+
+            if(!isDefined(str1))
+                return -1;
+
+            if(!isDefined(str2))
+                return 1;
+
+            return ("" + str1).localeCompare("" + str2, undefined, { numeric: true, sensitivity: 'base' });
+        },
 
         number: function(n1, n2) {
             return n1 - n2;


### PR DESCRIPTION
Using the 'numeric' and 'sensitivity' options in localCompare to provide a Natural Sort strategy.

This will keep the original intended sorting in place but provide an alternative for those that wish to use natural sorting for alphanumeric characters.

Example:

Normal string sort

1. Item 1
2. Item 10
3. Item 2

Natural sort:

1. Item 1
2. Item 2
3. Item 10

Usage is the same as any other sort strategy in jsGrid:

`{
    fields: [
      ...
      { name: "Name", sorter: "stringNaturalSort" },
      ...
    ]
}`